### PR TITLE
Change links in documentation & add flag to invite contributors file

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@ Please help us process github issues faster by providing the following informati
 - [ ] Bug report  <!-- Please search GitHub for a similar issue or PR before submitting -->
 - [ ] Feature request
 - [ ] Documentation issue or request
-- [ ] Support request => Please do not submit support request here, instead see https://github.com/flyve-mdm/angularjs-glpi/blob/master/CONTRIBUTING.md#questions-or-doubts
+- [ ] Support request => Please do not submit support request here, instead see https://github.com/glpi-project/angularjs-glpi/blob/develop/CONTRIBUTING.md#questions-or-doubts
 
 ## Current behavior
 

--- a/.github/invite-contributors.yml
+++ b/.github/invite-contributors.yml
@@ -1,2 +1,3 @@
+isOutside: true
 # Team Name
 team: contributors

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GLPI banner](https://user-images.githubusercontent.com/29282308/31666160-8ad74b1a-b34b-11e7-839b-043255af4f58.png)
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](http://www.repostatus.org/badges/latest/wip.svg)](http://www.repostatus.org/#wip)
 [![Greenkeeper badge](https://badges.greenkeeper.io/glpi-project/angularjs-glpi.svg)](https://greenkeeper.io/)
-[![License](https://img.shields.io/github/license/glpi-project/angularjs-glpi.svg?&label=License)](https://github.com/glpi-project/angularjs-glpi/blob/master/LICENSE.md)
+[![License](https://img.shields.io/github/license/glpi-project/angularjs-glpi.svg?&label=License)](https://github.com/glpi-project/angularjs-glpi/blob/develop/LICENSE.md)
 [![Follow twitter](https://img.shields.io/twitter/follow/glpi_project.svg?style=social&label=Twitter&style=flat-square)](https://twitter.com/glpi_project)
 [![Telegram Group](https://img.shields.io/badge/Telegram-Group-blue.svg)](https://t.me/glpien)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
@@ -68,7 +68,7 @@ See [the tags section of our GitHub project](https://github.com/glpi-project/ang
 
 ## Contact
 
-Chat with us via IRC in [#glpi on freenode](http://webchat.freenode.net/?channels=glpi]) or [@glpien on Telegram](https://t.me/glpien).
+Chat with us via IRC in [#glpi on freenode](http://webchat.freenode.net/?channels=glpi) or [@glpien on Telegram](https://t.me/glpien).
 
 ## Contribute
 


### PR DESCRIPTION
# Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [Conventional Commit](https://conventionalcommits.org/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The IRC link adds an square bracket at the end of # GLPI
There's missing a flag to add contributors as outside collaborators
Wrong link of support in issue template
Issue #2 

## What is the new behavior

Links fixed and flag added

## Does this PR introduce a breaking change

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Hi, @ajsb85 

This PR closes #2  

Related PR:

* #25 
* #7 
* #12 